### PR TITLE
Adds Lands compatibility, and fixes startup issues.

### DIFF
--- a/Dangerous-Caves/pom.xml
+++ b/Dangerous-Caves/pom.xml
@@ -105,5 +105,11 @@
             <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>Lands</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/Dangerous-Caves/src/main/java/me/imdanix/caves/generator/CaveGenerator.java
+++ b/Dangerous-Caves/src/main/java/me/imdanix/caves/generator/CaveGenerator.java
@@ -56,6 +56,7 @@ public class CaveGenerator extends BlockPopulator implements Manager<StructureGr
     public CaveGenerator(Configuration cfg) {
         this.cfg = cfg;
         structures = new HashMap<>();
+        this.structuresPool = new WeightedPool<>();
     }
 
     @Override

--- a/Dangerous-Caves/src/main/java/me/imdanix/caves/mobs/MobsManager.java
+++ b/Dangerous-Caves/src/main/java/me/imdanix/caves/mobs/MobsManager.java
@@ -96,6 +96,7 @@ public class MobsManager implements Manager<CustomMob>, Listener, Tickable, Conf
         this.dynamics = dynamics;
         mobs = new HashMap<>();
         worlds = new HashSet<>();
+        this.mobsPool = new WeightedPool<>();
     }
 
     @Override

--- a/Dangerous-Caves/src/main/java/me/imdanix/caves/regions/Regions.java
+++ b/Dangerous-Caves/src/main/java/me/imdanix/caves/regions/Regions.java
@@ -22,6 +22,7 @@ import me.imdanix.caves.Manager;
 import me.imdanix.caves.configuration.Configurable;
 import me.imdanix.caves.regions.griefprevention.GriefPreventionFlagsManager;
 import me.imdanix.caves.regions.griefprevention.GriefPreventionManager;
+import me.imdanix.caves.regions.lands.LandsManager;
 import me.imdanix.caves.regions.worldguard.WorldGuard6FlagsManager;
 import me.imdanix.caves.regions.worldguard.WorldGuard6Manager;
 import me.imdanix.caves.regions.worldguard.WorldGuard7FlagsManager;
@@ -102,6 +103,10 @@ public enum Regions implements Manager<RegionManager>, Configurable {
             managers.put("griefprevention", new GriefPreventionManager());
             if(Bukkit.getPluginManager().isPluginEnabled("GriefPreventionFlags"))
                 managers.put("griefprevention-flags", new GriefPreventionFlagsManager());
+        }
+
+        if (Bukkit.getPluginManager().isPluginEnabled("Lands")) {
+            managers.put("lands", new LandsManager());
         }
 
         managers.values().forEach(RegionManager::onEnable);

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
     <!--<module>regions/Residence</module>-->
         <module>Dangerous-Caves</module>
         <module>build</module>
+        <module>regions/Lands</module>
     </modules>
     <packaging>pom</packaging>
 

--- a/regions/Lands/pom.xml
+++ b/regions/Lands/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Dangerous Caves 2 | Make your caves scary
+  ~ Copyright (C) 2020  imDaniX
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>dangerous-caves-main</artifactId>
+        <groupId>me.imdanix.plugins</groupId>
+        <version>2</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>Lands</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>1.16.1-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>regionmanager</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.angeschossen</groupId>
+            <artifactId>LandsAPI</artifactId>
+            <version>4.8.18</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/regions/Lands/src/main/java/me/imdanix/caves/regions/lands/LandsManager.java
+++ b/regions/Lands/src/main/java/me/imdanix/caves/regions/lands/LandsManager.java
@@ -1,0 +1,48 @@
+package me.imdanix.caves.regions.lands;
+
+import me.angeschossen.lands.api.integration.LandsIntegration;
+import me.angeschossen.lands.api.land.Area;
+import me.angeschossen.lands.api.land.enums.LandSetting;
+import me.imdanix.caves.regions.CheckType;
+import me.imdanix.caves.regions.RegionManager;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+
+public class LandsManager implements RegionManager {
+
+    private LandsIntegration landsIntegration;
+
+    @Override
+    public void onEnable() {
+        this.landsIntegration = new LandsIntegration(Bukkit.getPluginManager().getPlugin("DangerousCaves"));
+    }
+
+    @Override
+    public String getName() {
+        return "lands";
+    }
+
+    @Override
+    public boolean test(CheckType type, Location location) {
+        Area area = landsIntegration.getAreaByLoc(location);
+
+        if (area == null) {
+            return true;
+        }
+
+        switch (type) {
+            case ENTITY: {
+                return area.hasLandSetting(LandSetting.ENTITY_GRIEFING);
+            }
+            case BLOCK: {
+                return area.hasLandSetting(LandSetting.LEAF_DECAY);
+            }
+            case EFFECT: {
+                return true;
+            }
+            default: {
+                return false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This commit adds Lands compatibility (https://www.spigotmc.org/resources/lands-minecraft-land-claim-plugin-grief-prevention-protection-gui-management-wars-1-16-support.53313/) to this project. Since there's no custom flag support, I decided on the following checks:

- Entity Griefing flag will decide if an ENTITY check comes out as true or false.
- Leaf Decay flag will decide if a BLOCK check comes out as true or false. Since the main feature of BLOCK checks is cave decay, I decided this was the most appropiate flag.
- EFFECT checks are always true. There's no appropiate flag for this. Maybe monster spawning? I don't know.

Maybe make this configurable by the user? Open to suggestions.

I also fixed the startup issues I encountered with this beta build, seems like one got fixed but the cave one didn't.